### PR TITLE
Fix Geronimo Config Impl not loading the default file property source…

### DIFF
--- a/impl/src/main/java/org/apache/geronimo/config/DefaultConfigBuilder.java
+++ b/impl/src/main/java/org/apache/geronimo/config/DefaultConfigBuilder.java
@@ -181,7 +181,7 @@ public class DefaultConfigBuilder implements ConfigBuilder {
 
         configSources.add(new SystemEnvConfigSource());
         configSources.add(new SystemPropertyConfigSource());
-        configSources.addAll(new PropertyFileConfigSourceProvider("/META-INF/microprofile-config.properties", true, forClassLoader).getConfigSources(forClassLoader));
+        configSources.addAll(new PropertyFileConfigSourceProvider("META-INF/microprofile-config.properties", true, forClassLoader).getConfigSources(forClassLoader));
 
         return configSources;
     }

--- a/impl/src/test/java/org/apache/geronimo/config/test/internal/ProviderTest.java
+++ b/impl/src/test/java/org/apache/geronimo/config/test/internal/ProviderTest.java
@@ -32,13 +32,14 @@ import org.testng.annotations.Test;
 
 public class ProviderTest extends Arquillian {
     private static final String SOME_KEY = "org.apache.geronimo.config.test.internal.somekey";
+	private static final String PROPERTY_FILE_KEY = "org.apache.geronimo.config.test.internal.filekey";
 
     @Deployment
     public static WebArchive deploy() {
         System.setProperty(SOME_KEY, "someval");
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "configProviderTest.jar")
-                .addClasses(ProviderTest.class, SomeBean.class)
+                .addClasses(ProviderTest.class, SomeBean.class, PropertyFileBean.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return ShrinkWrap
@@ -47,6 +48,7 @@ public class ProviderTest extends Arquillian {
     }
 
     private @Inject SomeBean someBean;
+	private @Inject PropertyFileBean propertyFileBean;
 
 
     @Test
@@ -59,6 +61,11 @@ public class ProviderTest extends Arquillian {
         myconfig = someBean.getMyconfig();
         Assert.assertEquals(myconfig, "otherval");
     }
+	
+	@Test
+    public void testDefaultPropertySourceConfigProvider() {
+        Assert.assertEquals(propertyFileBean.getMyfileconfig(), "fileval");
+    }
 
 
     @RequestScoped
@@ -70,6 +77,19 @@ public class ProviderTest extends Arquillian {
 
         public String getMyconfig() {
             return myconfig.get();
+        }
+
+    }
+	
+	@RequestScoped
+	 public static class PropertyFileBean {
+		
+		@Inject
+        @ConfigProperty(name=PROPERTY_FILE_KEY)
+        private Provider<String> myfileconfig;
+		
+		public String getMyfileconfig() {
+            return myfileconfig.get();
         }
 
     }

--- a/impl/src/test/resources/META-INF/microprofile-config.properties
+++ b/impl/src/test/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+org.apache.geronimo.config.test.internal.filekey = fileval


### PR DESCRIPTION
Fix Geronimo Config Impl not loading the default file property source 'META-INF/microprofile-config.properties'